### PR TITLE
bootstrap.sh: fix do_package bug

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -44,29 +44,29 @@ function do_dotfile_install(){
 
 function do_dotfiles(){
 
-dotfile=""
+    dotfile=""
 
-while IFS="" read -r dotfile; do
-    if ! file_exists "${dotfile}"; then
-        echo -n "Ensuring the copy of the ${dotfile} dotfile: "
-        if ! do_dotfile_install "${dotfile}"; then
-            echo "fail"
-            exit 1
-        else
-            echo "ok"
-        fi
-    else
-        if ! file_changes "${dotfile}"; then
-            echo -n "The file was changed, ensuring the copy of the ${dotfile} dotfile: "
+    while IFS="" read -r dotfile; do
+        if ! file_exists "${dotfile}"; then
+            echo -n "Ensuring the copy of the ${dotfile} dotfile: "
             if ! do_dotfile_install "${dotfile}"; then
                 echo "fail"
                 exit 1
             else
                 echo "ok"
             fi
+        else
+            if ! file_changes "${dotfile}"; then
+                echo -n "The file was changed, ensuring the copy of the ${dotfile} dotfile: "
+                if ! do_dotfile_install "${dotfile}"; then
+                    echo "fail"
+                    exit 1
+                else
+                    echo "ok"
+                fi
+            fi
         fi
-    fi
-done <<< "$(cd dotfiles && find . -type f)"
+    done <<< "$(cd dotfiles && find . -type f)"
 
 }
 
@@ -84,19 +84,19 @@ function do_package_install(){
 
 function do_packages(){
 
-package=""
+    package=""
 
-while IFS="" read -r package; do
-    if ! package_exists "${package}"; then
-        echo -n "Ensuring the installation of the ${package} package: "
-        if ! do_package_install "${package}"; then
-            echo "fail"
-            exit 1
-        else
-            echo "ok"
+    while IFS="" read -u 666 -r package; do
+        if ! package_exists "${package}"; then
+            echo -n "Ensuring the installation of the ${package} package: "
+            if ! do_package_install "${package}"; then
+                echo "fail"
+                exit 1
+            else
+                echo "ok"
+            fi
         fi
-    fi
-done < ./packages.txt
+    done 666< ./packages.txt
 
 }
 


### PR DESCRIPTION
    The bootstrap script install only one package for each
    execution. This PR fix this behaivor.

    The do_package() function use a while looping reading from
    stdin the file ./packages.txt to get the packages that need
    to be install. Eatch line of the file contais the name of
    the package that will be install, the function check if the
    package is installed, if is not than calls do_install_package()
    function with the name of the package.

    So, the do_install_package() function run the brew install
    command, that reads from stdin the ./packages.txt file. As a
    result, the script only install the first package that need
    to be install, because the command brew install consumes the
    rest of the file and the while loope terminates.

    A robust workaround is to change the file descriptor from which
    the read command receives input. This is accomplished by two
    modifications: the -u argument to read, and the redirection
    operator for < ./packages.txt

    Bash handles several filenames specially when they are used in
    redirections, as described in the following table:

     /dev/fd/fd
            If fd is a valid integer, file descriptor fd is duplicated.
     /dev/stdin
            File descriptor 0 is duplicated.
     /dev/stdout
            File descriptor 1 is duplicated.
     /dev/stderr
            File descriptor 2 is duplicated.

    Redirections using file descriptors greater than 9 should be
    used with care, as they may conflict with file descriptors the
    shell uses internally.

    Note: this happens not just for brew install, but for any command
    that reads stdin (ssh, mplayer, ffmpeg etc).